### PR TITLE
Updated dependency to recent faraday-middleware

### DIFF
--- a/flying-sphinx.gemspec
+++ b/flying-sphinx.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thinking-sphinx',    ['>= 0']
   s.add_runtime_dependency 'net-ssh',            ['>= 2.0.23']
   s.add_runtime_dependency 'multi_json',         ['~> 1.0.1']
-  s.add_runtime_dependency 'faraday',            ['~> 0.6.1']
-  s.add_runtime_dependency 'faraday_middleware', ['~> 0.6.3']
+  s.add_runtime_dependency 'faraday_middleware', ['~> 0.7.0']
   s.add_runtime_dependency 'rash',               ['~> 0.3.0']
   
   s.add_development_dependency 'rake',            ['0.8.7']


### PR DESCRIPTION
A friend of mine has a freak gemfile conflict when using flying-sphinx together with the omniauth gem - both ultimately depend from the faraday gem, but they're pointing to different versions.

I updated the dependency from faraday (actually, I updated the dependency from faraday-middleware, which carries faraday along, and removed the explicit dependency from faraday). Now both flying-sphinx and omniauth use faraday post-0.7. The specs still run, and I see they exercise the lines where faraday is used.
