### PR TITLE
Relax faraday gem restriction

### DIFF
--- a/flying-sphinx.gemspec
+++ b/flying-sphinx.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'riddle',             ['>= 1.5.0']
   s.add_runtime_dependency 'net-ssh',            ['>= 2.0.23']
   s.add_runtime_dependency 'multi_json',         ['>= 1.0.1']
-  s.add_runtime_dependency 'faraday_middleware', ['~> 0.7.0']
+  s.add_runtime_dependency 'faraday_middleware', ['~> 0.7']
   s.add_runtime_dependency 'rash',               ['~> 0.3.0']
 
   s.add_development_dependency 'rake',            ['0.8.7']


### PR DESCRIPTION
I relaxed the faraday gem restriction to allow the new 0.8.1 version. I was running into a dependency conflict in my app as the twitter gem depends on the new faraday version, and flying sphinx was set at ~> 0.7.3. I ran all the tests and they all worked.
