### PR TITLE
Delayed::Job delete_all does not accept arguments in delayed_job (4.1.5)

### DIFF
--- a/lib/flying_sphinx/commands/index_sql.rb
+++ b/lib/flying_sphinx/commands/index_sql.rb
@@ -18,9 +18,9 @@ class FlyingSphinx::Commands::IndexSQL < FlyingSphinx::Commands::Base
   end
 
   def clear_jobs
-    ::Delayed::Job.delete_all(
-      "handler LIKE '--- !ruby/object:FlyingSphinx::%'"
-    ) if defined?(::Delayed) && ::Delayed::Job.table_exists?
+    ::Delayed::Job.
+      where("handler LIKE '--- !ruby/object:FlyingSphinx::%'").
+      delete_all if defined?(::Delayed) && ::Delayed::Job.table_exists?
   end
 
   def indexing_options


### PR DESCRIPTION
There is a call in the index_sql to Delayed::Job. The call deletes all the jobs. But as of delayed_job 4.1.5 there is no argument to the delete_all method. Not sure if there was an argument before.
